### PR TITLE
Fixes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,9 @@ default[:valhalla][:extracts]                                    = %w(
 
 # configuration
 default[:valhalla][:config]                                      = 'valhalla.json'
+default[:valhalla][:log][:mjolnir]                               = "#{node[:valhalla][:log_dir]}/mjolnir.log"
+default[:valhalla][:log][:thor]                                  = "#{node[:valhalla][:log_dir]}/thor.log"
+default[:valhalla][:log][:tyr]                                   = "#{node[:valhalla][:log_dir]}/tyr.log"
 
 # retile
 default[:valhalla][:retile][:cut_tiles_timeout]                  = 86_400 # 4 hours

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,25 +5,29 @@
 #
 
 # where to do some install work
-default[:valhalla][:base_dir]              = '/opt/valhalla'
-default[:valhalla][:tile_dir]              = "#{node[:valhalla][:base_dir]}/tiles"
-default[:valhalla][:log_dir]               = "#{node[:valhalla][:base_dir]}/log"
-default[:valhalla][:conf_dir]              = "#{node[:valhalla][:base_dir]}/etc"
-default[:valhalla][:src_dir]               = "#{node[:valhalla][:base_dir]}/src"
-default[:valhalla][:extracts_dir]          = "#{node[:valhalla][:base_dir]}/extracts"
+default[:valhalla][:base_dir]                                    = '/opt/valhalla'
+default[:valhalla][:tile_dir]                                    = "#{node[:valhalla][:base_dir]}/tiles"
+default[:valhalla][:log_dir]                                     = "#{node[:valhalla][:base_dir]}/log"
+default[:valhalla][:conf_dir]                                    = "#{node[:valhalla][:base_dir]}/etc"
+default[:valhalla][:src_dir]                                     = "#{node[:valhalla][:base_dir]}/src"
+default[:valhalla][:extracts_dir]                                = "#{node[:valhalla][:base_dir]}/extracts"
 
 # the repos
-default[:valhalla][:github][:base]         = 'https://github.com/valhalla'
-default[:valhalla][:github][:repos]        = %w(midgard baldr mjolnir loki odin thor tyr)
-default[:valhalla][:github][:revision]     = 'master'
+default[:valhalla][:github][:base]                               = 'https://github.com/valhalla'
+default[:valhalla][:github][:repos]                              = %w(midgard baldr mjolnir loki odin thor tyr)
+default[:valhalla][:github][:revision]                           = 'master'
 
 # valhalla user to create
-default[:valhalla][:user][:name]           = 'valhalla'
-default[:valhalla][:user][:home]           = '/home/valhalla'
+default[:valhalla][:user][:name]                                 = 'valhalla'
+default[:valhalla][:user][:home]                                 = '/home/valhalla'
 
 # the data to create tiles
-default[:valhalla][:extracts]              = %w(
-  http://download.geofabrik.de/europe/liechtenstein-latest.osm.pbf
+default[:valhalla][:extracts]                                    = %w(
+http://download.geofabrik.de/europe/liechtenstein-latest.osm.pbf
 )
+
 # configuration
-default[:valhalla][:config]                = 'valhalla.json'
+default[:valhalla][:config]                                      = 'valhalla.json'
+
+# retile
+default[:valhalla][:retile][:cut_tiles_timeout]                  = 86_400 # 4 hours

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ default[:valhalla][:user][:home]                                 = '/home/valhal
 
 # the data to create tiles
 default[:valhalla][:extracts]                                    = %w(
-http://download.geofabrik.de/europe/liechtenstein-latest.osm.pbf
+  http://download.geofabrik.de/europe/liechtenstein-latest.osm.pbf
 )
 
 # configuration

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,11 +6,11 @@
 
 # where to do some install work
 default[:valhalla][:base_dir]              = '/opt/valhalla'
-default[:valhalla][:tile_dir]              = "#{default[:valhalla][:base_dir]}/tiles"
-default[:valhalla][:log_dir]               = "#{default[:valhalla][:base_dir]}/log"
-default[:valhalla][:conf_dir]              = "#{default[:valhalla][:base_dir]}/etc"
-default[:valhalla][:src_dir]               = "#{default[:valhalla][:base_dir]}/src"
-default[:valhalla][:extracts_dir]          = "#{default[:valhalla][:base_dir]}/extracts"
+default[:valhalla][:tile_dir]              = "#{node[:valhalla][:base_dir]}/tiles"
+default[:valhalla][:log_dir]               = "#{node[:valhalla][:base_dir]}/log"
+default[:valhalla][:conf_dir]              = "#{node[:valhalla][:base_dir]}/etc"
+default[:valhalla][:src_dir]               = "#{node[:valhalla][:base_dir]}/src"
+default[:valhalla][:extracts_dir]          = "#{node[:valhalla][:base_dir]}/extracts"
 
 # the repos
 default[:valhalla][:github][:base]         = 'https://github.com/valhalla'

--- a/recipes/retile.rb
+++ b/recipes/retile.rb
@@ -41,6 +41,7 @@ execute 'cut tiles' do
           #{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]} #{extracts} \
           >/tmp/pbfgraphbuilder.out 2>&1"
   cwd     node[:valhalla][:base_dir]
+  timeout node[:valhalla][:retile][:cut_tiles_timeout]
 end
 
 # TODO: add an execute for publishing the possible data issues to maproulette

--- a/recipes/retile.rb
+++ b/recipes/retile.rb
@@ -38,7 +38,8 @@ execute 'cut tiles' do
   action  :nothing
   user    node[:valhalla][:user][:name]
   command "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib pbfgraphbuilder -c \
-          #{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]} #{extracts}"
+          #{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]} #{extracts} \
+          >/tmp/pbfgraphbuilder.out 2>&1"
   cwd     node[:valhalla][:base_dir]
 end
 

--- a/recipes/retile.rb
+++ b/recipes/retile.rb
@@ -38,8 +38,7 @@ execute 'cut tiles' do
   action  :nothing
   user    node[:valhalla][:user][:name]
   command "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib pbfgraphbuilder -c \
-          #{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]} #{extracts} \
-          >/tmp/pbfgraphbuilder.out 2>&1"
+          #{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]} #{extracts}"
   cwd     node[:valhalla][:base_dir]
   timeout node[:valhalla][:retile][:cut_tiles_timeout]
 end

--- a/recipes/serve.rb
+++ b/recipes/serve.rb
@@ -10,6 +10,7 @@ runit_service 'tyr-service' do
   log             true
   default_logger  true
   sv_timeout      60
+  retries         3
   env(
     'LD_LIBRARY_PATH' => '/usr/lib:/usr/local/lib',
     'PYTHONPATH'      => '/usr/local/lib/python2.7/dist-packages'

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -4,8 +4,6 @@
 # Recipe:: setup
 #
 
-include_recipe 'valhalla::retile'
-
 # make the valhalla user
 user_account node[:valhalla][:user][:name] do
   manage_home   true
@@ -30,15 +28,6 @@ end
     mode      0755
     owner     node[:valhalla][:user][:name]
   end
-end
-
-# move the config file into place
-template "#{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]}" do
-  source "#{node[:valhalla][:config]}.erb"
-  mode   0644
-  owner  node[:valhalla][:user][:name]
-
-  notifies :run, 'execute[retile]', :delayed
 end
 
 # install all the deps
@@ -72,4 +61,15 @@ bash 'update alternatives' do
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90;
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90;
   EOH
+end
+
+include_recipe 'valhalla::retile'
+
+# move the config file into place
+template "#{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]}" do
+  source "#{node[:valhalla][:config]}.erb"
+  mode   0644
+  owner  node[:valhalla][:user][:name]
+
+  notifies :run, 'execute[retile]', :delayed
 end

--- a/templates/default/sv-tyr-service-run.erb
+++ b/templates/default/sv-tyr-service-run.erb
@@ -2,6 +2,4 @@
 
 cd <%= node[:valhalla][:src_dir] %>/tyr
 exec 2>&1
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-export PYTHONPATH=/usr/local/lib/python2.7/dist-packages
 exec chpst -u <%= node[:valhalla][:user][:name] %> -e /etc/sv/tyr-service/env python py/server.py <%= node[:valhalla][:conf_dir] %>/<%= node[:valhalla][:config] %>

--- a/templates/default/valhalla.json.erb
+++ b/templates/default/valhalla.json.erb
@@ -18,12 +18,16 @@
       "way_function": "ways_proc"
     },
     "logging": {
-      "type": "std_out"
+      "type": "file",
+      "file_name": "<%= node[:valhalla][:log][:mjolnir] %>",
+      "reopen_interval": "60"
     }
   },
   "thor": {
     "logging": {
-      "type": "std_out"
+      "type": "file",
+      "file_name": "<%= node[:valhalla][:log][:thor] %>",
+      "reopen_interval": "60"
     }
   },
   "tyr": {


### PR DESCRIPTION
- don't need to export vars twice
- make the best of an ordering conundrum by making sure we go through setup tasks first
- attributes should reference 'node' when the intent is to inherit from the upstream default (otherwise they would have to be overridden explicitly)
