### PR TITLE
always install the software by default

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -38,55 +38,52 @@ template "#{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]}" do
   owner  node[:valhalla][:user][:name]
 end
 
-# we only need tyr it has everything
-%w(tyr).each do |repo|
-  # clone software
-  git "#{node[:valhalla][:src_dir]}/#{repo}" do
-    action            :sync
-    user              node[:valhalla][:user][:name]
-    repo              "#{node[:valhalla][:github][:base]}/#{repo}.git"
-    revision          node[:valhalla][:github][:revision]
-    enable_submodules true
-    depth             1
+# clone software
+execute "clone tyr" do
+  action            :run
+  user              node[:valhalla][:user][:name]
+  command           "rm -rf tyr && git clone --depth=1 --recurse-submodules --single-branch --branch=master \
+                     #{node[:valhalla][:github][:base]}/tyr.git"
+  cwd               "#{node[:valhalla][:src_dir]}"
 
-    notifies :run, "execute[dependencies #{repo}]", :immediately
-    notifies :run, "execute[configure #{repo}]", :immediately
-    notifies :run, "execute[build #{repo}]", :immediately
-    notifies :run, "execute[install #{repo}]", :immediately
-  end
 
-  # dependencies
-  execute "dependencies #{repo}" do
-    action  :nothing
-    command "scripts/dependencies.sh #{node[:valhalla][:src_dir]}"
-    cwd     "#{node[:valhalla][:src_dir]}/#{repo}"
-  end
+  notifies :run, 'execute[dependencies tyr]', :immediately
+  notifies :run, 'execute[configure tyr]', :immediately
+  notifies :run, 'execute[build tyr]', :immediately
+  notifies :run, 'execute[install tyr]', :immediately
+end
 
-  # configure
-  execute "configure #{repo}" do
-    action  :nothing
-    user    node[:valhalla][:user][:name]
-    command './autogen.sh && ./configure CPPFLAGS="-DLOGGING_LEVEL_INFO" \
-             --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local \
-             --with-valhalla-sif=/usr/local --with-valhalla-mjolnir=/usr/local \
-             --with-valhalla-loki=/usr/local --with-valhalla-odin=/usr/local \
-             --with-valhalla-thor=/usr/local --with-valhalla-tyr=/usr/local \
-             CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE'
-    cwd     "#{node[:valhalla][:src_dir]}/#{repo}"
-  end
+# dependencies
+execute "dependencies tyr" do
+  action  :nothing
+  command "scripts/dependencies.sh #{node[:valhalla][:src_dir]}"
+  cwd     "#{node[:valhalla][:src_dir]}/tyr"
+end
 
-  # build
-  execute "build #{repo}" do
-    action  :nothing
-    user    node[:valhalla][:user][:name]
-    command "make -j#{node[:cpu][:total]}"
-    cwd     "#{node[:valhalla][:src_dir]}/#{repo}"
-  end
+# configure
+execute "configure tyr" do
+  action  :nothing
+  user    node[:valhalla][:user][:name]
+  command './autogen.sh && ./configure CPPFLAGS="-DLOGGING_LEVEL_INFO" \
+           --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local \
+           --with-valhalla-sif=/usr/local --with-valhalla-mjolnir=/usr/local \
+           --with-valhalla-loki=/usr/local --with-valhalla-odin=/usr/local \
+           --with-valhalla-thor=/usr/local --with-valhalla-tyr=/usr/local \
+           CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE'
+  cwd     "#{node[:valhalla][:src_dir]}/tyr"
+end
 
-  # install
-  execute "install #{repo}" do
-    action  :nothing
-    command "make -j#{node[:cpu][:total]} install"
-    cwd     "#{node[:valhalla][:src_dir]}/#{repo}"
-  end
+# build
+execute "build tyr" do
+  action  :nothing
+  user    node[:valhalla][:user][:name]
+  command "make -j#{node[:cpu][:total]}"
+  cwd     "#{node[:valhalla][:src_dir]}/tyr"
+end
+
+# install
+execute "install tyr" do
+  action  :nothing
+  command "make -j#{node[:cpu][:total]} install"
+  cwd     "#{node[:valhalla][:src_dir]}/tyr"
 end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -39,13 +39,12 @@ template "#{node[:valhalla][:conf_dir]}/#{node[:valhalla][:config]}" do
 end
 
 # clone software
-execute "clone tyr" do
+execute 'clone tyr' do
   action            :run
   user              node[:valhalla][:user][:name]
   command           "rm -rf tyr && git clone --depth=1 --recurse-submodules --single-branch --branch=master \
                      #{node[:valhalla][:github][:base]}/tyr.git"
   cwd               "#{node[:valhalla][:src_dir]}"
-
 
   notifies :run, 'execute[dependencies tyr]', :immediately
   notifies :run, 'execute[configure tyr]', :immediately
@@ -54,14 +53,14 @@ execute "clone tyr" do
 end
 
 # dependencies
-execute "dependencies tyr" do
+execute 'dependencies tyr' do
   action  :nothing
   command "scripts/dependencies.sh #{node[:valhalla][:src_dir]}"
   cwd     "#{node[:valhalla][:src_dir]}/tyr"
 end
 
 # configure
-execute "configure tyr" do
+execute 'configure tyr' do
   action  :nothing
   user    node[:valhalla][:user][:name]
   command './autogen.sh && ./configure CPPFLAGS="-DLOGGING_LEVEL_INFO" \
@@ -74,7 +73,7 @@ execute "configure tyr" do
 end
 
 # build
-execute "build tyr" do
+execute 'build tyr' do
   action  :nothing
   user    node[:valhalla][:user][:name]
   command "make -j#{node[:cpu][:total]}"
@@ -82,7 +81,7 @@ execute "build tyr" do
 end
 
 # install
-execute "install tyr" do
+execute 'install tyr' do
   action  :nothing
   command "make -j#{node[:cpu][:total]} install"
   cwd     "#{node[:valhalla][:src_dir]}/tyr"


### PR DESCRIPTION
this is just to make sure we always have all the latest software. previously it would update only where it needed to and that really didnt make sense. also we only really work with one repo now so the others were already being force installed.

obviously we wont be doing t his forever, at some point in the future we'll get a stable version in ppa form. for now this eases the pushing of updates to aws
