### PR TITLE
faster test

### DIFF
--- a/recipes/_restart.rb
+++ b/recipes/_restart.rb
@@ -9,7 +9,7 @@ include_recipe 'runit::default'
 # httpd
 runit_service 'prime-httpd' do
   action  :restart
-  only_if "test -d #{node[:runit][:sv_dir]}/prime-httpd"
+  only_if "test -h #{node[:runit][:service_dir]}/prime-httpd"
 end
 
 # cake layers
@@ -17,14 +17,14 @@ end
   # proxy
   runit_service "proxyd-#{layer}" do
     action  :restart
-    only_if "test -d #{node[:runit][:sv_dir]}/proxyd-#{layer}"
+    only_if "test -h #{node[:runit][:service_dir]}/proxyd-#{layer}"
   end
 
   # workers
   (0..(node[:valhalla][:workers][:count] - 1)).step(1).each do |num|
     runit_service "workerd-#{layer}-#{num}" do
       action  :restart
-      only_if "test -d #{node[:runit][:sv_dir]}/workerd-#{layer}-#{num}"
+      only_if "test -h #{node[:runit][:service_dir]}/workerd-#{layer}-#{num}"
     end
   end
 end

--- a/recipes/_restart.rb
+++ b/recipes/_restart.rb
@@ -9,7 +9,7 @@ include_recipe 'runit::default'
 # httpd
 runit_service 'prime-httpd' do
   action  :restart
-  only_if "test $(service --status-all 2>&1 | grep -cF 'prime-httpd') = 1"
+  only_if "test -d #{node[:runit][:sv_dir]}/prime-httpd"
 end
 
 # cake layers
@@ -17,14 +17,14 @@ end
   # proxy
   runit_service "proxyd-#{layer}" do
     action  :restart
-    only_if "test $(service --status-all 2>&1 | grep -cF 'proxyd-#{layer}') = 1"
+    only_if "test -d #{node[:runit][:sv_dir]}/proxyd-#{layer}"
   end
 
   # workers
   (0..(node[:valhalla][:workers][:count] - 1)).step(1).each do |num|
     runit_service "workerd-#{layer}-#{num}" do
       action  :restart
-      only_if "test $(service --status-all 2>&1 | grep -cF 'workerd-#{layer}-#{num}') = 1"
+      only_if "test -d #{node[:runit][:sv_dir]}/workerd-#{layer}-#{num}"
     end
   end
 end


### PR DESCRIPTION
Turns out running 'service' 32 times for each worker layer is kind of slow. This functions the same way and should be much quicker.
