### PR TITLE
- create a temp dir for use for osmosis change files, which current get

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,7 @@ default[:valhalla][:base_dir]                                    = '/opt/valhall
 default[:valhalla][:tile_dir]                                    = "#{node[:valhalla][:base_dir]}/tiles"
 default[:valhalla][:log_dir]                                     = "#{node[:valhalla][:base_dir]}/log"
 default[:valhalla][:conf_dir]                                    = "#{node[:valhalla][:base_dir]}/etc"
+default[:valhalla][:temp_dir]                                    = "#{node[:valhalla][:base_dir]}/temp"
 default[:valhalla][:src_dir]                                     = "#{node[:valhalla][:base_dir]}/src"
 default[:valhalla][:lock_dir]                                    = "#{node[:valhalla][:base_dir]}/lock"
 default[:valhalla][:extracts_dir]                                = "#{node[:valhalla][:base_dir]}/extracts"

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -21,7 +21,8 @@ end
   node[:valhalla][:conf_dir],
   node[:valhalla][:src_dir],
   node[:valhalla][:lock_dir],
-  node[:valhalla][:extracts_dir]
+  node[:valhalla][:extracts_dir],
+  node[:valhalla][:temp_dir]
 ].each do |dir|
   directory dir do
     action    :create

--- a/templates/default/minutely_update.sh.erb
+++ b/templates/default/minutely_update.sh.erb
@@ -4,9 +4,9 @@
 BASE_DIR=""
 WORKDIR_OSM=""
 CHANGESET_DIR=""
-
-# programs we're going to use
 OSMOSIS="/usr/bin/osmosis"
+
+export JAVACMD_OPTIONS="-Djava.io.tmpdir=<%= node[:valhalla][:temp_dir] %>"
 
 # check they're all present
 if [ ! -e $OSMOSIS ]; then


### PR DESCRIPTION
  written to /tmp
- export JAVACMD_OPTIONS to change java's temp dir to get osmosis to
  write temp files to our location rather than forced to /tmp
