### PR TITLE
when getting tiles, first stop everything, and in the end check that …

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default[:valhalla][:service_stack]                               = 'YOUR_STACK_I
 default[:valhalla][:service_layer]                               = 'YOUR_LAYER_ID'
 default[:valhalla][:service_recipes]                             = 'valhalla::get_tiles'
 default[:valhalla][:min_service_update_instances]                = 2
+default[:valhalla][:health_check_timeout]                        = 300
 
 # configuration
 default[:valhalla][:config]                                      = "#{node[:valhalla][:conf_dir]}/valhalla.json"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'valhalla@mapzen.com'
 license          'MIT'
 description      'Installs/Configures valhalla'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.5'
+version          '0.4.6'
 
 recipe 'valhalla', 'Installs valhalla'
 

--- a/recipes/_restart.rb
+++ b/recipes/_restart.rb
@@ -28,3 +28,11 @@ end
     end
   end
 end
+
+# make sure everything is working by issuing a request
+execute 'test service' do
+  action  :run
+  user    node[:valhalla][:user][:name]
+  command "#{node[:valhalla][:conf_dir]}/health_check.sh"
+  cwd     node[:valhalla][:base_dir]
+end

--- a/recipes/get_tiles.rb
+++ b/recipes/get_tiles.rb
@@ -1,10 +1,31 @@
 # -*- coding: UTF-8 -*-
 #
 # Cookbook Name:: valhalla
-# Recipe:: fresh_tiles
+# Recipe:: get_tiles
 #
 
-execute 'pull_tiles' do
+execute 'stop service' do
+  action      :run
+  command     <<-EOH
+    service prime-httpd stop
+    count=$((#{node[:valhalla][:workers][:count]} - 1))
+    for i in loki thor odin tyr; do
+      service proxyd-${i} stop
+      for j in $(seq 0 ${count}); do
+        service workerd-${i}-${j} stop
+      done
+    done
+  EOH
+  cwd node[:valhalla][:base_dir]
+
+  notifies :run, 'execute[pull tiles]', :immediately
+  notifies :run, 'execute[extract tiles]', :immediately
+  notifies :run, 'execute[move tiles]', :immediately
+  notifies :run, 'execute[start service]', :immediately
+  notifies :run, 'execute[test service]', :immediately
+end
+
+execute 'pull tiles' do
   action  :run
   user    node[:valhalla][:user][:name]
   cwd     node[:valhalla][:base_dir]
@@ -29,19 +50,6 @@ execute 'extract tiles' do
   EOH
 end
 
-execute 'stop workers' do
-  action      :run
-  command     <<-EOH
-    count=$((#{node[:valhalla][:workers][:count]} - 1))
-    for i in loki thor odin tyr; do
-      for j in $(seq 0 ${count}); do
-        service workerd-${i}-${j} stop
-      done
-    done
-  EOH
-  cwd node[:valhalla][:base_dir]
-end
-
 execute 'move tiles' do
   action  :run
   user    node[:valhalla][:user][:name]
@@ -49,15 +57,24 @@ execute 'move tiles' do
   cwd     node[:valhalla][:base_dir]
 end
 
-execute 'start workers' do
+execute 'start service' do
   action  :run
   cwd     node[:valhalla][:base_dir]
   command <<-EOH
+    service prime-httpd start
     count=$((#{node[:valhalla][:workers][:count]} - 1))
     for i in loki thor odin tyr; do
+      service proxyd-${i} start
       for j in $(seq 0 ${count}); do
         service workerd-${i}-${j} start
       done
     done
   EOH
+end
+
+execute 'test service' do
+  action  :run
+  user    node[:valhalla][:user][:name]
+  command 'curl localhost:8080/route --fail --data \'{"locations":[{"lat":40.402918,"lon":-76.535017},{"lat":40.403654,"lon": -76.529846}],"costing":"auto"}\''
+  cwd     node[:valhalla][:base_dir]
 end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -41,7 +41,7 @@ template node[:valhalla][:config] do
 end
 
 # install all of the scripts for data motion
-%w(cut_tiles.sh minutely_update.sh push_tiles.py pull_tiles.py).each do |script|
+%w(cut_tiles.sh minutely_update.sh push_tiles.py pull_tiles.py health_check.sh).each do |script|
   template "#{node[:valhalla][:conf_dir]}/#{script}" do
     source "#{script}.erb"
     mode   0755

--- a/templates/default/health_check.sh.erb
+++ b/templates/default/health_check.sh.erb
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#keep checking while we havent run out of time
+start=$(date +%s)
+while [ $[$(date +%s) - $start] -lt <% node[:valhalla][:health_check_timeout] %> ]; do
+	curl localhost:<% node[:valhalla][:httpd][:port] %>/route --max-time 1 --fail --data '{"locations":[{"lat":40.402918,"lon":-76.535017},{"lat":40.403654,"lon": -76.529846}],"costing":"auto"}'
+	if [ $? -eq 0 ]; then
+		exit 0
+	fi
+	sleep 5
+done
+
+#never got a decent response try one last time
+curl localhost:<% node[:valhalla][:httpd][:port] %>/route --max-time 1 --fail --data '{"locations":[{"lat":40.402918,"lon":-76.535017},{"lat":40.403654,"lon": -76.529846}],"costing":"auto"}'
+exit $?


### PR DESCRIPTION
…its all working

when a service node takes a tile update it will now stop handling traffic until the data is there. an alternative approach would be to just spawn new instances and kill the olds ones (which is pretty appealing) but more complicated
