### PR TITLE
send MOAR to s3

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'valhalla@mapzen.com'
 license          'MIT'
 description      'Installs/Configures valhalla'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.5.0'
+version          '0.5.1'
 
 recipe 'valhalla', 'Installs valhalla'
 

--- a/templates/default/cut_tiles.sh.erb
+++ b/templates/default/cut_tiles.sh.erb
@@ -17,12 +17,14 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 cp -rp <%= node[:valhalla][:src_dir] %>/mjolnir/conf/*.lua <%= node[:valhalla][:conf_dir] %>
 
 # name the dir where this will go
-cur_tile_dir=$(dirname <%= node[:valhalla][:tile_dir] %>)/tiles_$(date +%Y_%m_%d-%H_%M_%S)
+stamp=$(date +%Y_%m_%d-%H_%M_%S)
+cur_tile_dir=$(dirname <%= node[:valhalla][:tile_dir] %>)/tiles_${stamp}
 
 # if we dont have admins we must create them
 extracts=$(find <%= node[:valhalla][:extracts_dir] %> -type f -name "*.pbf")
 admin_file=$(jq -r '.mjolnir.admin.admin_dir' <%= node[:valhalla][:config] %>)/$(jq -r '.mjolnir.admin.db_name' <%= node[:valhalla][:config] %>)
 transit_file=$(jq -r '.mjolnir.transit.transit_dir' <%= node[:valhalla][:config] %>)/$(jq -r '.mjolnir.transit.db_name' <%= node[:valhalla][:config] %>)
+stats_file=$(jq -r '.mjolnir.statistics.statistics_dir' <%= node[:valhalla][:config] %>)/$(jq -r '.mjolnir.statistics.db_name' <%= node[:valhalla][:config] %>)
 if [ ! -e $admin_file ]; then
   pbfadminbuilder -c <%= node[:valhalla][:config] %> $(find <%= node[:valhalla][:extracts_dir] %> -type f -name "*.pbf")
 fi
@@ -35,6 +37,9 @@ rm -rf *.bin
 # we can ship the whole tile dir to s3 anyway, admin connectivity and all
 pushd <%= node[:valhalla][:tile_dir] %>
 connectivitymap -c <%= node[:valhalla][:config] %>
+mv ${stats_file} $(basename ${stats_file} | sed -e "s/\(\.[^.]\+$\)/_${stamp}\1/g")
+stats_file=$(basename ${stats_file} | sed -e "s/\(\.[^.]\+$\)/_${stamp}\1/g")
+mv connectivity.json connectivity_${stamp}.json
 popd
 
 # backup files and tile dirs, keep the admin stuff though
@@ -52,7 +57,7 @@ if [ "<%= node[:valhalla][:with_updates] %>" == true ]; then
   {
     set +e
     tar pcf - -C ${cur_tile_dir} . | pigz -9 > ${cur_tile_dir}.tgz
-    <%= node[:valhalla][:conf_dir] %>/push_tiles.py ${cur_tile_dir}.tgz
+    <%= node[:valhalla][:conf_dir] %>/push_tiles.py connectivity_${stamp}.json ${stats_file} ${cur_tile_dir}.tgz
     rm -rf ${cur_tile_dir} ${cur_tile_dir}.tgz
   }&
 fi

--- a/templates/default/push_tiles.py.erb
+++ b/templates/default/push_tiles.py.erb
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import sys
 import os
+import stat
 import math
 import time
 import boto
@@ -12,7 +13,13 @@ def push_to_s3(file_name, bucket_name = '<%= node[:valhalla][:bucket] %>', bucke
   #check what we have in s3
   s3 = boto.connect_s3()
   bucket = s3.get_bucket(bucket_name)
-  keys = sorted([ k.key for k in bucket.get_all_keys() if k.key.startswith(bucket_dir + '/tiles_') if k.key.endswith('.tgz') ])
+  basename, extension = os.path.basename(filename)
+  if extension == '' or basename == '':
+    raise Exception('Sending extension-less or extension-only files isn't allowed')
+  prefix = basename[:basename.find('_')]
+  if prefix == basename[:-1]:
+    raise Exception('No prefix detected for freshness culling, when naming use: prefix_$(date +%Y_%m_%d-%H_%M_%S).ext')
+  keys = sorted([ k.key for k in bucket.get_all_keys() if k.key.startswith(bucket_dir + '/' + prefix) if k.key.endswith(extension) ])
   keys.reverse()
 
   #lets keep it to a managable amount of previous ones
@@ -116,8 +123,14 @@ if __name__ == "__main__":
     print('Wrong arguments', file=sys.stderr)
     sys.exit(1)
 
+  #check all the files are there
+  for f in sys.argv:
+    if stat.S_ISREG(os.stat(f).st_mode) == False:
+      raise Exception('Arguments should only be regular files')
+
   #push them to s3
-  push_to_s3(sys.argv[1], '<%= node[:valhalla][:bucket] %>', '<%= node[:valhalla][:bucket_dir] %>')
+  for f in sys.argv:
+    push_to_s3(f, '<%= node[:valhalla][:bucket] %>', '<%= node[:valhalla][:bucket_dir] %>')
 
   #update the service instances
   update_instances('<%= node[:valhalla][:service_elb] %>', '<%= node[:valhalla][:service_stack] %>', '<%= node[:valhalla][:service_layer] %>', list('<%= node[:valhalla][:service_recipes] %>'.split(',')))


### PR DESCRIPTION
this will all us (and whoever else is using aws) to send the connectivity map and the statistics sqlite database to s3 with a date stamp on it which matches the tileset (tgz). i havent tested this yet, so i'll be doing some adhoc testing before merging. 
