### PR TITLE
fetch transit for use in routing tiles

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,8 @@ default[:valhalla][:extracts]                                    = %w(
 )
 default[:valhalla][:with_updates]                                = false
 default[:valhalla][:with_transit]                                = false
-default[:valhalla][:transit_api_key]                             = ''
+default[:valhalla][:transitland_url]                             = 'http://transit.land'
+default[:valhalla][:transitland_api_key]                         = ''
 
 # where to put fresh tiles and who wants them
 default[:valhalla][:bucket]                                      = 'YOUR_BUCKET'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,7 @@ default[:valhalla][:extracts]                                    = %w(
 )
 default[:valhalla][:with_updates]                                = false
 default[:valhalla][:with_transit]                                = false
+default[:valhalla][:transit_api_key]                             = ''
 
 # where to put fresh tiles and who wants them
 default[:valhalla][:bucket]                                      = 'YOUR_BUCKET'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,7 +28,8 @@ default[:valhalla][:user][:home]                                 = '/home/valhal
 default[:valhalla][:extracts]                                    = %w(
   http://download.geofabrik.de/europe/liechtenstein-latest.osm.pbf
 )
-default[:valhalla][:with_updates]                                = false  # boolean
+default[:valhalla][:with_updates]                                = false
+default[:valhalla][:with_transit]                                = false
 
 # where to put fresh tiles and who wants them
 default[:valhalla][:bucket]                                      = 'YOUR_BUCKET'

--- a/recipes/get_transit_tiles.rb
+++ b/recipes/get_transit_tiles.rb
@@ -1,0 +1,25 @@
+# -*- coding: UTF-8 -*-
+#
+# Cookbook Name:: valhalla
+# Recipe:: get_transit_tiles
+#
+
+# cut tiles as a one-off
+execute 'get transit tiles' do
+  user    node[:valhalla][:user][:name]
+  cwd     node[:valhalla][:base_dir]
+  command <<-EOH
+    #{node[:valhalla][:conf_dir]}/cut_transit_tiles.sh >>#{node[:valhalla][:log_dir]}/cut_transit_tiles.log 2>&1
+  EOH
+  only_if { node[:valhalla][:with_updates] == false && node[:valhalla][:with_transit] == true }
+end
+
+# or install crontab to cut tiles all the time
+cron 'get transit tiles' do
+  user    node[:valhalla][:user][:name]
+  day     '*'
+  command <<-EOH
+    cd #{node[:valhalla][:base_dir]} && #{node[:valhalla][:conf_dir]}/cut_transit_tiles.sh >> #{node[:valhalla][:log_dir]}/cut_transit_tiles.log 2>&1
+  EOH
+  only_if { node[:valhalla][:with_updates] == true && node[:valhalla][:with_transit] == true }
+end

--- a/recipes/get_transit_tiles.rb
+++ b/recipes/get_transit_tiles.rb
@@ -4,7 +4,7 @@
 # Recipe:: get_transit_tiles
 #
 
-# cut tiles as a one-off
+# get transit tiles as a one-off
 execute 'get transit tiles' do
   user    node[:valhalla][:user][:name]
   cwd     node[:valhalla][:base_dir]
@@ -14,7 +14,7 @@ execute 'get transit tiles' do
   only_if { node[:valhalla][:with_updates] == false && node[:valhalla][:with_transit] == true }
 end
 
-# or install crontab to cut tiles all the time
+# or install crontab to get transit tiles all the time
 cron 'get transit tiles' do
   user    node[:valhalla][:user][:name]
   day     '*'

--- a/recipes/get_transit_tiles.rb
+++ b/recipes/get_transit_tiles.rb
@@ -9,7 +9,7 @@ execute 'get transit tiles' do
   user    node[:valhalla][:user][:name]
   cwd     node[:valhalla][:base_dir]
   command <<-EOH
-    #{node[:valhalla][:conf_dir]}/cut_transit_tiles.sh >>#{node[:valhalla][:log_dir]}/cut_transit_tiles.log 2>&1
+    #{node[:valhalla][:conf_dir]}/get_transit_tiles.sh >>#{node[:valhalla][:log_dir]}/transit.log 2>&1
   EOH
   only_if { node[:valhalla][:with_updates] == false && node[:valhalla][:with_transit] == true }
 end
@@ -19,7 +19,7 @@ cron 'get transit tiles' do
   user    node[:valhalla][:user][:name]
   day     '*'
   command <<-EOH
-    cd #{node[:valhalla][:base_dir]} && #{node[:valhalla][:conf_dir]}/cut_transit_tiles.sh >> #{node[:valhalla][:log_dir]}/cut_transit_tiles.log 2>&1
+    cd #{node[:valhalla][:base_dir]} && #{node[:valhalla][:conf_dir]}/get_transit_tiles.sh >> #{node[:valhalla][:log_dir]}/transit.log 2>&1
   EOH
   only_if { node[:valhalla][:with_updates] == true && node[:valhalla][:with_transit] == true }
 end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -42,7 +42,7 @@ template node[:valhalla][:config] do
 end
 
 # install all of the scripts for data motion
-%w(cut_tiles.sh minutely_update.sh push_tiles.py health_check.sh).each do |script|
+%w(cut_tiles.sh get_transit_tiles.sh minutely_update.sh push_tiles.py health_check.sh).each do |script|
   template "#{node[:valhalla][:conf_dir]}/#{script}" do
     source "#{script}.erb"
     mode   0755

--- a/templates/default/cut_tiles.sh.erb
+++ b/templates/default/cut_tiles.sh.erb
@@ -31,6 +31,12 @@ if [ ! -e $timezone_file ]; then
   <%= node[:valhalla][:src_dir] %>/mjolnir/scripts/create_tz_db.sh <%= node[:valhalla][:config] %>
 fi
 
+#transit data
+if [ -f <%= node[:valhalla][:transit_dir] %>.tgz ]; then
+  rm -rf <%= node[:valhalla][:transit_dir] %>
+  tar pxvf -C <%= node[:valhalla][:transit_dir] %> <%= node[:valhalla][:transit_dir] %>.tgz
+fi
+
 # cut tiles from the data
 pbfgraphbuilder -c <%= node[:valhalla][:config] %> $(find <%= node[:valhalla][:extracts_dir] %> -type f -name "*.pbf")
 rm -rf *.bin

--- a/templates/default/cut_tiles.sh.erb
+++ b/templates/default/cut_tiles.sh.erb
@@ -34,7 +34,8 @@ fi
 #transit data
 if [ -f <%= node[:valhalla][:transit_dir] %>.tgz ]; then
   rm -rf <%= node[:valhalla][:transit_dir] %>
-  tar pxvf -C <%= node[:valhalla][:transit_dir] %> <%= node[:valhalla][:transit_dir] %>.tgz
+  mkdir <%= node[:valhalla][:transit_dir] %>
+  tar pxvf <%= node[:valhalla][:transit_dir] %>.tgz -C <%= node[:valhalla][:transit_dir] %>
 fi
 
 # cut tiles from the data

--- a/templates/default/get_transit_tiles.sh.erb
+++ b/templates/default/get_transit_tiles.sh.erb
@@ -20,10 +20,8 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 #  tar pxvf <%= node[:valhalla][:transit_dir] %>.tgz -C <%= node[:valhalla][:transit_dir] %>_temp
 #fi
 
-#tar pxvf -C <%= node[:valhalla][:transit_dir] %>_temp <%= node[:valhalla][:transit_dir] %>.tgz
-
 # fetch the latest data
-transit_fetcher <%= node[:valhalla][:conf_dir] %> http://transit.land 5000 <%= node[:valhalla][:transit_dir] %>_temp <%= node[:valhalla][:transit_api_key] %>
+transit_fetcher <%= node[:valhalla][:conf_dir] %> <%= node[:valhalla][:transitland_url] %> 5000 <%= node[:valhalla][:transit_dir] %>_temp <%= node[:valhalla][:transitland_api_key] %>
 
 # tar it up
 tar pcf - -C <%= node[:valhalla][:transit_dir] %>_temp . | pigz -9 > <%= node[:valhalla][:transit_dir] %>_temp.tgz

--- a/templates/default/get_transit_tiles.sh.erb
+++ b/templates/default/get_transit_tiles.sh.erb
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# make sure only one is running at any time...
+LOCK_FILE="<%= node[:valhalla][:lock_dir] %>/cut_transit_tiles.lock"
+(set -C; : > ${LOCK_FILE}) 2> /dev/null
+if [ $? != "0" ]; then
+   echo "Lock file exists"
+   exit 0
+fi
+trap 'rm $LOCK_FILE' EXIT 1 2 3
+
+export PATH=$PATH:/usr/local/bin
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+# TODO: for incremental updates we'll want to first get a copy of the previous stuff
+#tar pxvf -C <%= node[:valhalla][:transit_dir] %>_temp <%= node[:valhalla][:transit_dir] %>.tgz
+
+# fetch the latest data
+transit_fetcher <%= node[:valhalla][:conf_dir] %> http://transit.land 5000 <%= node[:valhalla][:transit_dir] %>_temp <%= node[:valhalla][:transit_api_key] %>
+
+# tar it up
+tar pcf - -C <%= node[:valhalla][:transit_dir] %>_temp . | pigz -9 > <%= node[:valhalla][:transit_dir] %>_temp.tgz
+
+# and move it into place
+mv <%= node[:valhalla][:transit_dir] %>_temp.tgz <%= node[:valhalla][:transit_dir] %>.tgz

--- a/templates/default/get_transit_tiles.sh.erb
+++ b/templates/default/get_transit_tiles.sh.erb
@@ -14,6 +14,12 @@ export PATH=$PATH:/usr/local/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 # TODO: for incremental updates we'll want to first get a copy of the previous stuff
+#if [ -f <%= node[:valhalla][:transit_dir] %>.tgz ]; then
+#  rm -rf <%= node[:valhalla][:transit_dir] %>_temp
+#  mkdir <%= node[:valhalla][:transit_dir] %>_temp
+#  tar pxvf <%= node[:valhalla][:transit_dir] %>.tgz -C <%= node[:valhalla][:transit_dir] %>_temp
+#fi
+
 #tar pxvf -C <%= node[:valhalla][:transit_dir] %>_temp <%= node[:valhalla][:transit_dir] %>.tgz
 
 # fetch the latest data


### PR DESCRIPTION
this adds a bit of stuff to either run transit fetcher continually via cron, as a one off or not at all. currently the cron is set to daily so as to be able to test it immediately (since this is how mapzen turn by turn will be using it). the default will be to not run with transit and will need to be overridden by potential users.
