### PR TITLE
allow per layer config of min instances check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,7 +40,7 @@ default[:valhalla][:routing_service_stack]                       = 'YOUR_STACK_I
 default[:valhalla][:routing_service_layers]                      = 'YOUR_LAYER_IDS'
 default[:valhalla][:routing_service_elb]                         = 'YOUR_ELB_NAME'
 default[:valhalla][:routing_service_recipes]                     = 'valhalla::get_routing_tiles'
-default[:valhalla][:min_routing_service_update_instances]        = 2
+default[:valhalla][:min_layers_instances]                        = '1'
 default[:valhalla][:health_check_timeout]                        = 300
 if node[:opsworks] && node[:opsworks][:layers][:'matrix'] && node[:opsworks][:instance][:layers].include?('matrix')
   default[:valhalla][:health_check][:route_action]                 = 'one_to_many'

--- a/templates/default/push_tiles.py.erb
+++ b/templates/default/push_tiles.py.erb
@@ -52,7 +52,7 @@ def push_to_s3(file_name, bucket_name = '<%= node[:valhalla][:bucket] %>', bucke
   key.make_public()
 
 #get all the instances of a layer and run some recipes on each
-def update_instances(elb_name, stack, layer, recipes):
+def update_instances(elb_name, stack, layer, min_instances, recipes):
   #connect to opsworks
   opsworks = boto.connect_opsworks()
 
@@ -63,13 +63,13 @@ def update_instances(elb_name, stack, layer, recipes):
   #TODO: sort by instance name so that we always try the same one first
   #if we dont have enough machines to feel safe we give up
   instances = [ i for i in instances['Instances'] if i.get('Status') == 'online' ]
-  if len(instances) < <%= node[:valhalla][:min_routing_service_update_instances] %>:
+  if len(instances) < min_instances:
     raise Exception('Not enough instances in layer to risk the update')
 
   #connect to the elb and check which are in it
   elb = boto.connect_elb(elb_name)
   instances = [ i for i in instances if elb.describe_instance_health(elb_name, [i['Ec2InstanceId']])[0].state == 'InService' ]
-  if len(instances) < <%= node[:valhalla][:min_routing_service_update_instances] %>:
+  if len(instances) < min_instances:
     raise Exception('Not enough instances in elb to risk the update')
 
   #for each one
@@ -138,5 +138,8 @@ if __name__ == "__main__":
       print('%s is not a regular file' % f)
 
   #update the service instances
-  for layer in list('<%= node[:valhalla][:routing_service_layers] %>'.split(',')):
-    update_instances('<%= node[:valhalla][:routing_service_elb] %>', '<%= node[:valhalla][:routing_service_stack] %>', layer, list('<%= node[:valhalla][:routing_service_recipes] %>'.split(',')))
+  layers = '<%= node[:valhalla][:routing_service_layers] %>'.split(',')
+  min_layers_instances = '<%= node[:valhalla][:min_layers_instances] %>'.split(',')
+  recipes = '<%= node[:valhalla][:routing_service_recipes] %>'.split(',')
+  for layer, min_instances in zip(layers, min_layers_instances):
+    update_instances('<%= node[:valhalla][:routing_service_elb] %>', '<%= node[:valhalla][:routing_service_stack] %>', layer, int(min_instances), recipes)


### PR DESCRIPTION
the pushing of new data does a check to make sure there arent too few instances in a given layer before making said layers instances take an update. this is to reduce the risk of lowering availability too much.

since we now have mutliple layers (route and matrix) and they are configured to have different numbers of instances having one value makes it so that we arent making the right kind of checks. this pr changes that so that we can control the check per layer.

concretely this allows us to say, we want at least 3 routing instances in the routing elb before we'll do an update to them (one at a time) but also that we want at least 2 instances in the matrix elb before we update them one at a time. Before we could only pick one number that applied to all layers regardless of how many instances they had (and they are of course different)
