### PR TITLE
cull really old data

### DIFF
--- a/templates/default/push_tiles.py.erb
+++ b/templates/default/push_tiles.py.erb
@@ -14,13 +14,10 @@ def push_to_s3(file_name, bucket_name = '<%= node[:valhalla][:bucket] %>', bucke
   s3 = boto.connect_s3()
   bucket = s3.get_bucket(bucket_name)
   basename = os.path.basename(file_name)
-  basename, extension = os.path.splitext(basename)
-  if basename == '' or extension == '':
-    raise Exception('Sending extension-less or extension-only files is not allowed')
   prefix = basename[:basename.find('_') + 1]
-  if prefix == basename[:-1]:
+  if not prefix.endswith('_'):
     raise Exception('No prefix detected for freshness culling, when naming use: prefix_$(date +%Y_%m_%d-%H_%M_%S).ext')
-  keys = sorted([ k.key for k in bucket.get_all_keys() if k.key.startswith(bucket_dir + '/' + prefix) if k.key.endswith(extension) ])
+  keys = sorted([ k.key for k in bucket.get_all_keys(None, prefix=bucket_dir + '/' + prefix) ])
   keys.reverse()
 
   #lets keep it to a managable amount of previous ones


### PR DESCRIPTION
there was previously a measure installed in our s3 tile pushing stuff that kept the bucket from filling up. it was working fine until we added elevation data to the bucket. this pushed it over the 1000 key default limit that `boto` has when enumerating stuff in the bucket. looking at the boto api it turns you that you can give the key enumeration a `prefix` which we were using to weed stuff out manually anyway. so now we pass that in, and it only returns keys that match the stuff you are wanting to cull which should pretty much always be less than 1000 keys (until we start shipping the tiles unzipped, but thats a problem for future @kevinkreiser)

this has been kid tested and mother approved on the prod data producer
