### PR TITLE
get transit initially even if you'll get it via a cron later on

### DIFF
--- a/recipes/get_transit_tiles.rb
+++ b/recipes/get_transit_tiles.rb
@@ -11,7 +11,7 @@ execute 'get transit tiles' do
   command <<-EOH
     #{node[:valhalla][:conf_dir]}/get_transit_tiles.sh >>#{node[:valhalla][:log_dir]}/transit.log 2>&1
   EOH
-  only_if { node[:valhalla][:with_updates] == false && node[:valhalla][:with_transit] == true }
+  only_if { node[:valhalla][:with_transit] == true }
 end
 
 # or install crontab to get transit tiles all the time


### PR DESCRIPTION
its annoying that wed have to wait for the cron to get transit when making a new data producer machine. so this should make it get transit any time you are configured to want it. this is also useful if you dont want to get on a machine and do it manually.
