### PR TITLE
match the name in attributes.rb

### DIFF
--- a/templates/default/maproulette.json.erb
+++ b/templates/default/maproulette.json.erb
@@ -1,5 +1,5 @@
 {
-  "geojson_file": <%= node[:maproulette][:geojson] %>,
+  "geojson_file": <%= node[:maproulette][:geojson_file] %>,
   "recurring_tasks_file": <%= node[:maproulette][:recurring_tasks_file] %>,
   "server_url": <%= node[:maproulette][:server_url] %>,
   "api_key": <%= node[:maproulette][:api_key] %>,


### PR DESCRIPTION
the template replacement fails because this key doesnt appear in `attributes.rb` so we fix the key to match
